### PR TITLE
add yak_triobin rule to bin child reads

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -67,6 +67,7 @@ for i in sr_prefixes.keys():
 # rules to include
 include: 'rules/trio_hifiasm.smk'
 include: yak_rule
+include: 'rules/yak_triobin.smk'
 
 
 # build a list of targets
@@ -85,6 +86,10 @@ if 'alignment' in config['targets']:
     targets.extend([f"{output_dir}/{trio_id}/hifiasm/{child}.{hap}.{ref}.{suffix}"
         for hap in ['hap1', 'hap2']
         for suffix in ['bam', 'bam.bai']])
+# triobin kid reads
+if 'triobin' in config['targets']:
+    targets.extend([f"{output_dir}/{trio_id}/yak/{child}.{movie}.triobin.txt"
+        for movie in hifi_prefixes[child]])
 
 
 localrules: all, md5sum

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,3 +1,10 @@
+targets:
+  - kmers
+  - assembly
+  - alignment
+  - triobin
+
+
 tmpdir: '/tmp'
 
 

--- a/rules/trio_hifiasm.smk
+++ b/rules/trio_hifiasm.smk
@@ -51,7 +51,7 @@ rule hifiasm:
             (
                 hifiasm -o {params.prefix} -t {threads} {params.extras} \
                     -1 {input.pat_yak} -2 {input.mat_yak} {input.fasta} \
-                && (echo -e "hap1\t{params.hap1}\nhap2\t{params.hap2}" > {output_dir}/{trio_id}/hifiasm/{wildcards.sample}.asm.key.txt) \
+                && (echo -e "hap1\t{params.hap1}\tp\nhap2\t{params.hap2}\tm" > {output_dir}/{trio_id}/hifiasm/{wildcards.sample}.asm.key.txt) \
             ) > {log} 2>&1
             """
     

--- a/rules/yak_triobin.smk
+++ b/rules/yak_triobin.smk
@@ -1,0 +1,11 @@
+rule yak_triobin:
+    input:
+        fasta = f"{output_dir}/{trio_id}/fasta/{child}/{{movie}}.fasta",
+        pat_yak = f"{output_dir}/{trio_id}/yak/{config[trio_id]['father']['id']}.yak",
+        mat_yak = f"{output_dir}/{trio_id}/yak/{config[trio_id]['mother']['id']}.yak"
+    output: f"{output_dir}/{trio_id}/yak/{child}.{{movie}}.triobin.txt"
+    log: f"{output_dir}/{trio_id}/logs/yak_triobin/{child}.{{movie}}.log"
+    conda: "envs/yak.yaml"
+    params: extra = hifiasm_param
+    threads: 16
+    shell: "yak triobin {params.extra} -t {threads} {input.pat_yak} {input.mat_yak} {input.fasta} > {output} 2> {log}"


### PR DESCRIPTION
Using `yak triobin`, create a table that assigns each read to parent of origin using the same kmer thresholds as hifiasm.

Untested ☹️ 